### PR TITLE
#3 Possible memory leak because of Ticker

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -619,6 +619,7 @@ func (e *GExpect) ExpectSwitchCase(cs []Caser, timeout time.Duration) (string, [
 		}
 	}
 	chTicker := time.NewTicker(check)
+	defer chTicker.Stop()
 	// Read in current data and start actively check for matches.
 	var tbuf bytes.Buffer
 	if _, err := io.Copy(&tbuf, e); err != nil {


### PR DESCRIPTION
PR for Issue #3  
Added the Ticker Stop() 

Go test results:
```
~/goexpect$ go test
E0821 14:02:26.983666   11558 expect_test.go:135] Accept failed: accept tcp [::]:32844: use of closed network connection
E0821 14:02:27.002522   11558 expect_test.go:203] PTY cols/rows: 240/22 want: 120/40
E0821 14:02:27.002759   11558 expect_test.go:135] Accept failed: accept tcp [::]:41063: use of closed network connection
PASS
ok  	_/home/marek/goexpect	11.224s
```