### PR TITLE
Fix read() function err checking

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -1164,7 +1164,7 @@ func (e *GExpect) read(done chan struct{}, ptySync *sync.WaitGroup) {
 	buf := make([]byte, bufferSize)
 	for {
 		nr, err := e.pty.Master.Read(buf)
-		if err != nil || !e.check() {
+		if err != nil && !e.check() {
 			if e.teeWriter != nil {
 				e.teeWriter.Close()
 			}


### PR DESCRIPTION
The read function is failing tests with the inability to spawn a process with the error process not running. Upon investigation, I determined that the fact the read function had an || instead of a && caused a "pty: bad file descriptor" error and would not allow for further functions to execute and read from the buffer.