### PR TITLE
Respect timeout on Send command use

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ everytime the check is run. Can be used for troubleshooting and debugging of Spa
 
 The ChangeCheck option makes it possible to replace the Spawner Check function with a brand new one.
 
+### SendTimeout
+
+The SendTimeout set timeout on the `Send` command, without timeout the `Send` command will wait forewer for the expecter process.
+
+
 ## Basic Examples
 
 ### networkbit.ch


### PR DESCRIPTION
Before this PR, `Send` stuck forever if the spawned process does not ready to get input.

Fixes #30