### PR TITLE
Return the unmatched suffix back to the buffer so that it can be match again

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -714,7 +714,10 @@ func (e *GExpect) ExpectSwitchCase(cs []Caser, timeout time.Duration) (string, [
 			}
 
 			// Clear the buffer directly after match.
-			o := tbuf.String()
+			tbufString := tbuf.String()
+			matchIndex := rs[i].FindStringIndex(tbufString)
+			o := tbufString[0:matchIndex[1]]
+			e.ReturnUnmatchedSuffix(tbufString[matchIndex[1]:])
 			tbuf.Reset()
 
 			st := c.String()
@@ -1094,6 +1097,15 @@ func (e *GExpect) Read(p []byte) (nr int, err error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.out.Read(p)
+}
+
+// Return the unmatched suffix back to the buffer so that it can be matched again
+func (e *GExpect) ReturnUnmatchedSuffix(p string) {
+    e.mu.Lock()
+    defer e.mu.Unlock()
+    newBuffer := bytes.NewBufferString(p)
+    newBuffer.WriteString(e.out.String())
+    e.out = *newBuffer
 }
 
 // Send sends a string to spawned process.

--- a/expect.go
+++ b/expect.go
@@ -44,7 +44,7 @@ func NewStatus(code codes.Code, msg string) *Status {
 	return &Status{code, msg}
 }
 
-// NewStatusf returns a Status with the providead code and a formatted message.
+// NewStatusf returns a Status with the provided code and a formatted message.
 func NewStatusf(code codes.Code, format string, a ...interface{}) *Status {
 	return NewStatus(code, fmt.Sprintf(fmt.Sprintf(format, a...)))
 }
@@ -713,11 +713,11 @@ func (e *GExpect) ExpectSwitchCase(cs []Caser, timeout time.Duration) (string, [
 				}
 			}
 
-			// Clear the buffer directly after match.
+			// Return the part of the buffer that is not matched by the regular expression so that the next expect call will be able to match it.
 			tbufString := tbuf.String()
 			matchIndex := rs[i].FindStringIndex(tbufString)
 			o := tbufString[0:matchIndex[1]]
-			e.ReturnUnmatchedSuffix(tbufString[matchIndex[1]:])
+			e.returnUnmatchedSuffix(tbufString[matchIndex[1]:])
 			tbuf.Reset()
 
 			st := c.String()
@@ -1099,8 +1099,7 @@ func (e *GExpect) Read(p []byte) (nr int, err error) {
 	return e.out.Read(p)
 }
 
-// Return the unmatched suffix back to the buffer so that it can be matched again
-func (e *GExpect) ReturnUnmatchedSuffix(p string) {
+func (e *GExpect) returnUnmatchedSuffix(p string) {
     e.mu.Lock()
     defer e.mu.Unlock()
     newBuffer := bytes.NewBufferString(p)

--- a/expect_test.go
+++ b/expect_test.go
@@ -1096,7 +1096,7 @@ Router42>`},
 	}}
 
 	for _, tst := range tests {
-		exp, _, err := SpawnFake(tst.srv, tst.timeout)
+		exp, _, err := SpawnFake(tst.srv, tst.timeout, PartialMatch(true))
 		if err != nil {
 			if !tst.fail {
 				t.Errorf("%s: SpawnFake failed: %v", tst.name, err)

--- a/expect_test.go
+++ b/expect_test.go
@@ -1070,6 +1070,7 @@ func TestExpect(t *testing.T) {
 		srv     []Batcher
 		timeout time.Duration
 		re      *regexp.Regexp
+		re2     *regexp.Regexp
 	}{{
 		name: "Match prompt",
 		srv: []Batcher{
@@ -1078,7 +1079,8 @@ Pretty please don't hack my chassis
 
 router1> `},
 		},
-		re:      regexp.MustCompile("router1>"),
+		re:      regexp.MustCompile("hack"),
+		re2:     regexp.MustCompile("router1>"),
 		timeout: 2 * time.Second,
 	}, {
 		name: "Match fail",
@@ -1106,6 +1108,11 @@ Router42>`},
 			t.Errorf("%s: Expect(%q,%v) = %t want: %t , err: %v, out: %q", tst.name, tst.re.String(), tst.timeout, got, want, err, out)
 			continue
 		}
+        out, _, err = exp.Expect(tst.re2, tst.timeout)
+        if got, want := err != nil, tst.fail; got != want {
+            t.Errorf("%s: Expect(%q,%v) = %t want: %t , err: %v, out: %q", tst.name, tst.re.String(), tst.timeout, got, want, err, out)
+            continue
+        }
 	}
 }
 


### PR DESCRIPTION
This is intended to fix issue #27 