### PR TITLE
Improve tee

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -1073,6 +1073,9 @@ func (e *GExpect) waitForSession(r chan error, wait func() error, sIn io.WriteCl
 		for {
 			nr, err := out.Read(buf)
 			if err != nil || !e.check() {
+				if e.teeWriter != nil {
+					e.teeWriter.Close()
+				}
 				if err == io.EOF {
 					if e.verbose {
 						log.Printf("read closing down: %v", err)
@@ -1081,6 +1084,11 @@ func (e *GExpect) waitForSession(r chan error, wait func() error, sIn io.WriteCl
 				}
 				return
 			}
+			// Tee output to writer
+			if e.teeWriter != nil {
+				e.teeWriter.Write(buf[:nr])
+			}
+			// Add to buffer
 			e.mu.Lock()
 			e.out.Write(buf[:nr])
 			e.mu.Unlock()


### PR DESCRIPTION
Testing the Tee option, it was working only with `Spawn` and `SpawnWithArgs`.
It was only implemented in `runcmd` that those two Spawner uses.
Other Spawner uses `waitForSession`, so adding the Tee code to it fixed the issue.

@rjoleary as you implemented the initial Tee option, can you please help reviewing