### PR TITLE
Add circleci CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.11
+    # This conforms to Go workspace requirements (we are pre-modules)
+    working_directory: /go/src/github.com/google/goexpect
+
+    steps:
+      - checkout
+      - run:
+          name: Get dependencies
+          command: go get -v ./...
+      - run:
+          name: Run unit tests
+          command: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/google/goexpect.svg?style=svg)](https://circleci.com/gh/google/goexpect)
+
 This package is an implementation of [Expect](https://en.wikipedia.org/wiki/Expect) in [Go](golang.org).
 
 

--- a/examples/process/process.go
+++ b/examples/process/process.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/goexpect"
+	expect "github.com/google/goexpect"
 	"github.com/google/goterm/term"
 )
 
@@ -53,7 +53,7 @@ func main() {
 	}
 	out, match, err := e.Expect(piRE, timeout)
 	if err != nil {
-		glog.Exitf("e.Expect(%q,%v) failed: %v, out: %q", piRE.String(), timeout, out)
+		glog.Exitf("e.Expect(%q,%v) failed: %v, out: %q", piRE.String(), timeout, err, out)
 	}
 
 	fmt.Println(term.Bluef("Pi with %d digits: %s", scale, match[0]))


### PR DESCRIPTION
Hello,

this is in the same spirit of https://github.com/google/goterm/pull/4.

You can have a look at the current status of the build of my fork at https://circleci.com/gh/marco-m/goexpect/5.

If I understand correctly, there are some tests that require a TCP process around, see for example:

```
E0407 14:38:44.511598    2580 expect_test.go:137] Accept failed: accept tcp [::]:39922: use of closed network connection
```

If this is the case, I can have a look at this.

To make the build green I had to fix `examples/process/process.go`.  I also added the build badge to the README.

To make this work, in your account on https://circleci.com (github credentials), go to "Add Projects", select your goexpect repo and enable building.