### PR TITLE
fix SpawnFake session ending

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -880,6 +880,8 @@ func SpawnFake(b []Batcher, timeout time.Duration, opt ...Option) (*GExpect, <-c
 	if err != nil {
 		return nil, nil, err
 	}
+	// The Tee option should only affect the output not the batcher
+	srv.teeWriter = nil
 
 	go func() {
 		res, err := srv.ExpectBatch(b, timeout)
@@ -893,6 +895,7 @@ func SpawnFake(b []Batcher, timeout time.Duration, opt ...Option) (*GExpect, <-c
 		In:  rw,
 		Out: wr,
 		Close: func() error {
+			srv.Close()
 			return rw.Close()
 		},
 		Check: func() bool { return true },

--- a/expect_test.go
+++ b/expect_test.go
@@ -744,7 +744,7 @@ router1> `
 	}
 	re := regexp.MustCompile("router1>")
 	timeout := 2 * time.Second
-	exp, _, err := SpawnFake(srv, timeout, Tee(f))
+	exp, endch, err := SpawnFake(srv, timeout, Tee(f))
 	if err != nil {
 		t.Fatalf("SpawnFake failed: %v", err)
 	}
@@ -753,6 +753,8 @@ router1> `
 		t.Fatalf("Expect(%q,%v), err: %v, out: %q", re.String(), timeout, err, out)
 	}
 	exp.Close()
+	// wait for end
+	<-endch
 
 	// Check the tee'd output.
 	got, err := ioutil.ReadFile(fileName)


### PR DESCRIPTION
This was detected by using Tee and checking if the Tee `Close` function was
called. It was not ... adding the `srv.Close()` call made `waitForSession`
end (the <-endch whould no lomger block).
But the Tee `Close` function was called twice, because the batcher `srv` is
also using Tee while it should not.

Signed-off-by: Julien Viard de Galbert <julien.viard-de-galbert@itrenew.com>