### PR TITLE
ci: build also for Go 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,40 @@
+#
+# YAML anchor to keep configuration DRY.
+#
+common: &common
+  # This conforms to Go workspace requirements (we are pre-modules).
+  working_directory: /go/src/github.com/google/goexpect
+  steps:
+    - checkout
+    - run:
+        name: Go version
+        command: go version
+    - run:
+        name: Get dependencies
+        command: go get -v ./...
+    - run:
+        name: Run unit tests
+        command: go test -v ./...
+
+#
+# CircleCI.
+#
 version: 2
+
 jobs:
-  build:
+  go-1.11:
     docker:
       - image: circleci/golang:1.11
-    # This conforms to Go workspace requirements (we are pre-modules)
-    working_directory: /go/src/github.com/google/goexpect
+    <<: *common
+  go-1.12:
+    docker:
+      - image: circleci/golang:1.12
+    <<: *common
 
-    steps:
-      - checkout
-      - run:
-          name: Get dependencies
-          command: go get -v ./...
-      - run:
-          name: Run unit tests
-          command: go test -v ./...
+workflows:
+  version: 2
+  test:
+    # These will run in parallel.
+    jobs:
+      - go-1.11
+      - go-1.12


### PR DESCRIPTION
We now build for Go 1.11 and 1.12, in parallel.

It can be confusing to understand this in the web interface. Now each commit will trigger 2 parallel builds, one for go 1.11, one for go 1.12. The way to understand which is which is to look at the names `go-1.11` (defined in line 25) and `go-1.12` (defined in line 29), circled in the screenshot.

You can also see that both builds refer to the same commit hash, on the right.

![circleci](https://user-images.githubusercontent.com/3075069/60204036-5dcb8200-984e-11e9-93a9-900b7c494739.png)
