### PR TITLE
stop double logging 'Sent:' if verboseWriter not nil

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -1162,8 +1162,9 @@ func (e *GExpect) Send(in string) error {
 			if err != nil {
 				log.Printf("Write to Verbose Writer failed: %v", err)
 			}
+		} else {
+			log.Printf("Sent: %q", in)
 		}
-		log.Printf("Sent: %q", in)
 	}
 
 	return nil


### PR DESCRIPTION
this matches the logic here https://github.com/google/goexpect/blob/master/expect.go#L712-L725