### PR TITLE
README: telnet: fix English syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ func main() {
 ```
 
 In essence to run and attach to a process the `expect.Spawn(<cmd>,<timeout>)` is used.
-The spawn returns and Expecter that can rund `e.Expect` and `e.Send` commands to match information
+The spawn returns an Expecter `e` that can run `e.Expect` and `e.Send` commands to match information
 in the output and Send information in.
 
 *See the https://github.com/google/goexpect/blob/master/examples/newspawner/telnet.go  example for a slightly more fleshed out version*


### PR DESCRIPTION
Fix two typos and make it clear that `e` is the returned expecter.

Signed-off-by: Dan Kenigsberg <danken@gmail.com>