### PR TITLE
Add configurable bufferSize per GExpect instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ The ChangeCheck option makes it possible to replace the Spawner Check function w
 
 The SendTimeout set timeout on the `Send` command, without timeout the `Send` command will wait forewer for the expecter process.
 
+### BufferSize
+
+The BufferSize option provides a mechanism to configure the client io buffer size in bytes.
 
 ## Basic Examples
 


### PR DESCRIPTION
This PR makes bufferSize configurable.  This is particularly useful when
dealing with large PTY output.  The original default is maintained when
the BufferSize(...) option is not utilized.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>