### PR TITLE
gofmt expect.go

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -31,8 +31,8 @@ import (
 const DefaultTimeout = 60 * time.Second
 
 const (
-	checkDuration = 2 * time.Second // checkDuration how often to check for new output.
-	defaultBufferSize = 8192        // defaultBufferSize is the default io buffer size.
+	checkDuration     = 2 * time.Second // checkDuration how often to check for new output.
+	defaultBufferSize = 8192            // defaultBufferSize is the default io buffer size.
 )
 
 // Status contains an errormessage and a status code.


### PR DESCRIPTION
#65 introduced configurable bufferSize per GExpect instance.
This change just includes the result of running `gofmt`, since
#65 did not include the correct spacing for a few constants.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>